### PR TITLE
Fix/pyright pin and suppress torch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,10 +31,11 @@ repos:
       - id: pyright
         name: pyright
         entry: pyright
-        language: node
+        language: python
         pass_filenames: false
         types: [python]
-        additional_dependencies: ["pyright"]
+        # pin it so everyone's on the same pyright
+        additional_dependencies: ["pyright==1.1.409"]
         args:
           - --project=pyproject.toml
   # - repo: https://github.com/RobertCraigie/pyright-python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,11 @@ addopts = [
   "--import-mode=importlib"
 ]
 
+[tool.pyright]
+venvPath = "."  # look for the venv at ./venv
+venv = "venv"
+reportPrivateImportUsage = "none"  # torch C-ext re-exports, just noise
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Edited pre-commit-config.yaml to pin the pyright hook to `pyright==1.1.409`. In pyproject.toml I also ignored the torch `reportPrivateImportusage` since those are torch C-ext re-reports, which are just noise (also commented this on the line). Verified that pre-commit run pyright now produces 12 errors which @bing-j mentioned are expected, 11 llm.py and 1 ppo override. Torch false-positives are gone. 

Just one note for review `vencPath` / `venv` hardcodes the README-prescribed `./venv`/ Anyone with a differently-located vent (poetry cache) would need pyright pointed elsewhere. Also as a side issue, setting `reportPrivateImportUsage` to none is global not just torch, however, it is a very specific situation for that to pop up and will only happen on private-import misuse. Might want to look into it if we want to be extra safe. 